### PR TITLE
added right click event on context menu

### DIFF
--- a/chrome/js/background.js
+++ b/chrome/js/background.js
@@ -1,5 +1,4 @@
 "use strict";
-
 chrome.runtime.onInstalled.addListener(function () {
   chrome.declarativeContent.onPageChanged.removeRules(undefined, function () {
     chrome.declarativeContent.onPageChanged.addRules([
@@ -12,5 +11,14 @@ chrome.runtime.onInstalled.addListener(function () {
         actions: [new chrome.declarativeContent.ShowPageAction()]
       }
     ]);
+  });
+  chrome.contextMenus.removeAll();
+  chrome.contextMenus.create({
+    id: "enhance",
+    title: "CSI Enhance",
+    contexts: ["selection"],
+  });
+  chrome.contextMenus.onClicked.addListener((info, tabs) => {
+    console.log(info.selectionText)
   });
 });

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -11,7 +11,11 @@
   "page_action": {
     "default_popup": "views/popup.html"
   },
-  "permissions": ["declarativeContent", "activeTab"],
+  "permissions": [
+    "declarativeContent",
+    "activeTab",
+    "contextMenus"
+  ],
   "content_scripts": [
     {
       "matches": ["http://*/*","https://*/*"],


### PR DESCRIPTION
1. Console log of context menu is not shown in normal place. To view it click on "Inspect Views background page" - as shown below

<img width="403" alt="Screen Shot 2020-07-27 at 4 37 17 PM" src="https://user-images.githubusercontent.com/28331176/88589638-70068980-d027-11ea-9fc7-41439d0fae8a.png">

2. To test: Upload new package, highlight something, right click menu, click on CSI enhance. Should see text selection in the console menu shown above
